### PR TITLE
Synthesis parameter randomization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.vscode
 *.log
 tmp/
 

--- a/src/cpp/piper.hpp
+++ b/src/cpp/piper.hpp
@@ -55,10 +55,17 @@ struct SynthesisConfig {
   float lengthScale = 1.0f;
   float noiseW = 0.8f;
 
+  // randomization
+  float noiseScaleDelta = 0.05f;
+  float lengthScaleDelta = 0.05f;
+  float noiseWDelta = 0.05f;
+  float volumeDelta = 0.05f;
+
   // Audio settings
   int sampleRate = 22050;
   int sampleWidth = 2; // 16-bit
   int channels = 1;    // mono
+  float volume = 1.0f; // full scale
 
   // Speaker id from 0 to numSpeakers - 1
   std::optional<SpeakerId> speakerId;


### PR DESCRIPTION
Added natural distribution randomization for synthesis parameters, so that they are not equal on each cycle, but fluctuate +- delta value (which is presumably small).

Expectation is to get a more natural less robotic voicing.

- `noiseScaleDelta` alters noise scale within [noiseScale - noiseScaleDelta; noiseScale + noiseScaleDelta]
- `lengthScaleDelta`  alters length scale within [lengthScale - lengthScaleDelta; lengthScale + lengthScaleDelta], and sentence silence at the end of the sentence is altered in the same way
- `noiseWDelta` alters noise w within [noiseW - noiseWDelta; noiseW + noiseWDelta]
- `volumeDelta` alters volume within [volume - volumeDelta; volume]

All the delta values are absolute from the original, except `volumeDelta` which is relative to 1.0.